### PR TITLE
fix blurry titles and image by avoiding non-integral positions and sizes

### DIFF
--- a/SYFlatButton/SYFlatButton/SYFlatButton.m
+++ b/SYFlatButton/SYFlatButton/SYFlatButton.m
@@ -125,7 +125,7 @@
     self.imageLayer.frame = self.bounds;
     self.imageLayer.mask = ({
         CALayer *layer = [CALayer layer];
-        NSRect rect = NSMakeRect(x, y, imageSize.width, imageSize.height);
+        NSRect rect = NSMakeRect(round(x), round(y), imageSize.width, imageSize.height);
         layer.frame = rect;
         layer.contents = (__bridge id _Nullable)[self.image CGImageForProposedRect:&rect context:nil hints:nil];
         layer;
@@ -190,7 +190,7 @@
     }
     
     // Setup title layer
-    self.titleLayer.frame = NSMakeRect(x, y, titleSize.width, titleSize.height);
+    self.titleLayer.frame = NSMakeRect(round(x), round(y), ceil(titleSize.width), ceil(titleSize.height));
     self.titleLayer.string = self.title;
     self.titleLayer.font = (__bridge CFTypeRef _Nullable)(self.font);
     self.titleLayer.fontSize = self.font.pointSize;


### PR DESCRIPTION
The title and image in the button could appear blurry because of non-integral values for x/y and width/height. See attached images.

![before](https://cloud.githubusercontent.com/assets/5726765/23569196/68358b76-005e-11e7-80f0-511bc7de8d92.png)
![after](https://cloud.githubusercontent.com/assets/5726765/23569197/685af604-005e-11e7-9b14-900ef97de6bb.png)