### PR TITLE
Updated code to support macOS versions earlier than 10.12

### DIFF
--- a/SYFlatButton/SYFlatButton/SYFlatButton.m
+++ b/SYFlatButton/SYFlatButton/SYFlatButton.m
@@ -79,8 +79,24 @@
     CGFloat x = 0.0; // Image's origin x
     CGFloat y = 0.0; // Image's origin y
     
+    NSCellImagePosition effectiveImagePosition = self.imagePosition;
+    
+    if (@available(macOS 10.12, *)) {
+        switch(self.imagePosition) {
+            case NSImageTrailing:
+                effectiveImagePosition = NSImageRight;
+                break;
+            case NSImageLeading:
+                effectiveImagePosition = NSImageLeft;
+                break;
+            default:
+                //no mapping needed
+                break;
+        }
+    }
+    
     // Caculate the image's and title's position depends on button's imagePosition and imageHugsTitle property
-    switch (self.imagePosition) {
+    switch (effectiveImagePosition) {
         case NSNoImage:
             return;
             break;
@@ -94,26 +110,40 @@
             y = (buttonSize.height - imageSize.height) / 2.0;
             break;
         }
-        case NSImageLeading:
         case NSImageLeft: {
-            x = self.imageHugsTitle ? ((buttonSize.width - imageSize.width - titleSize.width) / 2.0 - self.spacing) : self.spacing;
+            if (@available(macOS 10.12, *)) {
+                x = self.imageHugsTitle ? ((buttonSize.width - imageSize.width - titleSize.width) / 2.0 - self.spacing) : self.spacing;
+            } else {
+                x = self.spacing;
+            }
             y = (buttonSize.height - imageSize.height) / 2.0;
             break;
         }
-        case NSImageTrailing:
         case NSImageRight: {
-            x = self.imageHugsTitle ? ((buttonSize.width - imageSize.width + titleSize.width) / 2.0 + self.spacing) : (buttonSize.width - imageSize.width - self.spacing);
+            if (@available(macOS 10.12, *)) {
+                x = self.imageHugsTitle ? ((buttonSize.width - imageSize.width + titleSize.width) / 2.0 + self.spacing) : (buttonSize.width - imageSize.width - self.spacing);
+            } else {
+                x = (buttonSize.width - imageSize.width - self.spacing);
+            }
             y = (buttonSize.height - imageSize.height) / 2.0;
             break;
         }
         case NSImageAbove: {
             x = (buttonSize.width - imageSize.width) / 2.0;
-            y = self.imageHugsTitle ? ((buttonSize.height - imageSize.height - titleSize.height) / 2.0 - self.spacing) : self.spacing;
+            if (@available(macOS 10.12, *)) {
+                y = self.imageHugsTitle ? ((buttonSize.height - imageSize.height - titleSize.height) / 2.0 - self.spacing) : self.spacing;
+            } else {
+                y = self.spacing;
+            }
             break;
         }
         case NSImageBelow: {
             x = (buttonSize.width - imageSize.width) / 2.0;
-            y = self.imageHugsTitle ? ((buttonSize.height - imageSize.height + titleSize.height) / 2.0 + self.spacing) : (buttonSize.height - imageSize.height - self.spacing);
+            if (@available(macOS 10.12, *)) {
+                y = self.imageHugsTitle ? ((buttonSize.height - imageSize.height + titleSize.height) / 2.0 + self.spacing) : (buttonSize.height - imageSize.height - self.spacing);
+            } else {
+                y = (buttonSize.height - imageSize.height - self.spacing);
+            }
             break;
         }
         default: {
@@ -146,8 +176,24 @@
     CGFloat x = 0.0; // Title's origin x
     CGFloat y = 0.0; // Title's origin y
     
+    NSCellImagePosition effectiveImagePosition = self.imagePosition;
+    
+    if (@available(macOS 10.12, *)) {
+        switch(self.imagePosition) {
+            case NSImageTrailing:
+                effectiveImagePosition = NSImageRight;
+                break;
+            case NSImageLeading:
+                effectiveImagePosition = NSImageLeft;
+                break;
+            default:
+                //no mapping needed
+                break;
+        }
+    }
+    
     // Caculate the image's and title's position depends on button's imagePosition and imageHugsTitle property
-    switch (self.imagePosition) {
+    switch (effectiveImagePosition) {
         case NSImageOnly: {
             return;
             break;
@@ -162,25 +208,39 @@
             y = (buttonSize.height - titleSize.height) / 2.0;
             break;
         }
-        case NSImageLeading:
         case NSImageLeft: {
-            x = self.imageHugsTitle ? ((buttonSize.width + imageSize.width - titleSize.width) / 2.0 + self.spacing) : (buttonSize.width - titleSize.width - self.spacing);
+            if (@available(macOS 10.12, *)) {
+                x = self.imageHugsTitle ? ((buttonSize.width + imageSize.width - titleSize.width) / 2.0 + self.spacing) : (buttonSize.width - titleSize.width - self.spacing);
+            } else {
+                x = (buttonSize.width - titleSize.width - self.spacing);
+            }
             y = (buttonSize.height - titleSize.height) / 2.0;
             break;
         }
-        case NSImageTrailing:
         case NSImageRight: {
-            x = self.imageHugsTitle ? ((buttonSize.width - imageSize.width - titleSize.width) / 2.0 - self.spacing) : self.spacing;
+            if (@available(macOS 10.12, *)) {
+                x = self.imageHugsTitle ? ((buttonSize.width - imageSize.width - titleSize.width) / 2.0 - self.spacing) : self.spacing;
+            } else {
+                x = self.spacing;
+            }
             y = (buttonSize.height - titleSize.height) / 2.0;
             break;
         }
         case NSImageAbove: {
             x = (buttonSize.width - titleSize.width) / 2.0;
-            y = self.imageHugsTitle ? ((buttonSize.height + imageSize.height - titleSize.height) / 2.0 + self.spacing) : (buttonSize.height - titleSize.height - self.spacing);
+            if (@available(macOS 10.12, *)) {
+                y = self.imageHugsTitle ? ((buttonSize.height + imageSize.height - titleSize.height) / 2.0 + self.spacing) : (buttonSize.height - titleSize.height - self.spacing);
+            } else {
+                y = (buttonSize.height - titleSize.height - self.spacing);
+            }
             break;
         }
         case NSImageBelow: {
-            y = self.imageHugsTitle ? ((buttonSize.height - imageSize.height - titleSize.height) / 2.0 - self.spacing) : self.spacing;
+            if (@available(macOS 10.12, *)) {
+                y = self.imageHugsTitle ? ((buttonSize.height - imageSize.height - titleSize.height) / 2.0 - self.spacing) : self.spacing;
+            } else {
+                y = self.spacing;
+            }
             x = (buttonSize.width - titleSize.width) / 2.0;
             break;
         }

--- a/SYFlatButton/SYFlatButton/SYFlatButton.m
+++ b/SYFlatButton/SYFlatButton/SYFlatButton.m
@@ -79,23 +79,14 @@
     CGFloat x = 0.0; // Image's origin x
     CGFloat y = 0.0; // Image's origin y
     
-    NSCellImagePosition effectiveImagePosition = self.imagePosition;
-    
-    if (@available(macOS 10.12, *)) {
-        switch(self.imagePosition) {
-            case NSImageTrailing:
-                effectiveImagePosition = NSImageRight;
-                break;
-            case NSImageLeading:
-                effectiveImagePosition = NSImageLeft;
-                break;
-            default:
-                //no mapping needed
-                break;
-        }
-    }
-    
     // Caculate the image's and title's position depends on button's imagePosition and imageHugsTitle property
+
+    NSCellImagePosition effectiveImagePosition = [self effectiveImagePositionFrom:self.imagePosition];
+    BOOL effectiveImageHugsTitle = NO;
+    if (@available(macOS 10.12, *)) {
+        effectiveImageHugsTitle = self.imageHugsTitle;
+    }
+
     switch (effectiveImagePosition) {
         case NSNoImage:
             return;
@@ -111,39 +102,23 @@
             break;
         }
         case NSImageLeft: {
-            if (@available(macOS 10.12, *)) {
-                x = self.imageHugsTitle ? ((buttonSize.width - imageSize.width - titleSize.width) / 2.0 - self.spacing) : self.spacing;
-            } else {
-                x = self.spacing;
-            }
+            x = effectiveImageHugsTitle ? ((buttonSize.width - imageSize.width - titleSize.width) / 2.0 - self.spacing) : self.spacing;
             y = (buttonSize.height - imageSize.height) / 2.0;
             break;
         }
         case NSImageRight: {
-            if (@available(macOS 10.12, *)) {
-                x = self.imageHugsTitle ? ((buttonSize.width - imageSize.width + titleSize.width) / 2.0 + self.spacing) : (buttonSize.width - imageSize.width - self.spacing);
-            } else {
-                x = (buttonSize.width - imageSize.width - self.spacing);
-            }
+            x = effectiveImageHugsTitle ? ((buttonSize.width - imageSize.width + titleSize.width) / 2.0 + self.spacing) : (buttonSize.width - imageSize.width - self.spacing);
             y = (buttonSize.height - imageSize.height) / 2.0;
             break;
         }
         case NSImageAbove: {
             x = (buttonSize.width - imageSize.width) / 2.0;
-            if (@available(macOS 10.12, *)) {
-                y = self.imageHugsTitle ? ((buttonSize.height - imageSize.height - titleSize.height) / 2.0 - self.spacing) : self.spacing;
-            } else {
-                y = self.spacing;
-            }
+            y = effectiveImageHugsTitle ? ((buttonSize.height - imageSize.height - titleSize.height) / 2.0 - self.spacing) : self.spacing;
             break;
         }
         case NSImageBelow: {
             x = (buttonSize.width - imageSize.width) / 2.0;
-            if (@available(macOS 10.12, *)) {
-                y = self.imageHugsTitle ? ((buttonSize.height - imageSize.height + titleSize.height) / 2.0 + self.spacing) : (buttonSize.height - imageSize.height - self.spacing);
-            } else {
-                y = (buttonSize.height - imageSize.height - self.spacing);
-            }
+            y = effectiveImageHugsTitle ? ((buttonSize.height - imageSize.height + titleSize.height) / 2.0 + self.spacing) : (buttonSize.height - imageSize.height - self.spacing);
             break;
         }
         default: {
@@ -176,23 +151,14 @@
     CGFloat x = 0.0; // Title's origin x
     CGFloat y = 0.0; // Title's origin y
     
-    NSCellImagePosition effectiveImagePosition = self.imagePosition;
+    // Caculate the image's and title's position depends on button's imagePosition and imageHugsTitle property
     
+    NSCellImagePosition effectiveImagePosition = [self effectiveImagePositionFrom:self.imagePosition];
+    BOOL effectiveImageHugsTitle = NO;
     if (@available(macOS 10.12, *)) {
-        switch(self.imagePosition) {
-            case NSImageTrailing:
-                effectiveImagePosition = NSImageRight;
-                break;
-            case NSImageLeading:
-                effectiveImagePosition = NSImageLeft;
-                break;
-            default:
-                //no mapping needed
-                break;
-        }
+        effectiveImageHugsTitle = self.imageHugsTitle;
     }
     
-    // Caculate the image's and title's position depends on button's imagePosition and imageHugsTitle property
     switch (effectiveImagePosition) {
         case NSImageOnly: {
             return;
@@ -209,38 +175,22 @@
             break;
         }
         case NSImageLeft: {
-            if (@available(macOS 10.12, *)) {
-                x = self.imageHugsTitle ? ((buttonSize.width + imageSize.width - titleSize.width) / 2.0 + self.spacing) : (buttonSize.width - titleSize.width - self.spacing);
-            } else {
-                x = (buttonSize.width - titleSize.width - self.spacing);
-            }
+            x = effectiveImageHugsTitle ? ((buttonSize.width + imageSize.width - titleSize.width) / 2.0 + self.spacing) : (buttonSize.width - titleSize.width - self.spacing);
             y = (buttonSize.height - titleSize.height) / 2.0;
             break;
         }
         case NSImageRight: {
-            if (@available(macOS 10.12, *)) {
-                x = self.imageHugsTitle ? ((buttonSize.width - imageSize.width - titleSize.width) / 2.0 - self.spacing) : self.spacing;
-            } else {
-                x = self.spacing;
-            }
+            x = effectiveImageHugsTitle ? ((buttonSize.width - imageSize.width - titleSize.width) / 2.0 - self.spacing) : self.spacing;
             y = (buttonSize.height - titleSize.height) / 2.0;
             break;
         }
         case NSImageAbove: {
             x = (buttonSize.width - titleSize.width) / 2.0;
-            if (@available(macOS 10.12, *)) {
-                y = self.imageHugsTitle ? ((buttonSize.height + imageSize.height - titleSize.height) / 2.0 + self.spacing) : (buttonSize.height - titleSize.height - self.spacing);
-            } else {
-                y = (buttonSize.height - titleSize.height - self.spacing);
-            }
+            y = effectiveImageHugsTitle ? ((buttonSize.height + imageSize.height - titleSize.height) / 2.0 + self.spacing) : (buttonSize.height - titleSize.height - self.spacing);
             break;
         }
         case NSImageBelow: {
-            if (@available(macOS 10.12, *)) {
-                y = self.imageHugsTitle ? ((buttonSize.height - imageSize.height - titleSize.height) / 2.0 - self.spacing) : self.spacing;
-            } else {
-                y = self.spacing;
-            }
+            y = effectiveImageHugsTitle ? ((buttonSize.height - imageSize.height - titleSize.height) / 2.0 - self.spacing) : self.spacing;
             x = (buttonSize.width - titleSize.width) / 2.0;
             break;
         }
@@ -436,6 +386,28 @@
         _titleLayer.delegate = self;
     }
     return _titleLayer;
+}
+
+#pragma mark - Helper Methods
+
+- (NSCellImagePosition)effectiveImagePositionFrom:(NSCellImagePosition) originalImagePosition {
+    
+    NSCellImagePosition effectiveImagePosition = originalImagePosition;
+    
+    if (@available(macOS 10.12, *)) {
+        switch(originalImagePosition) {
+            case NSImageTrailing:
+                effectiveImagePosition = NSImageRight;
+                break;
+            case NSImageLeading:
+                effectiveImagePosition = NSImageLeft;
+                break;
+            default:
+                //no mapping needed
+                break;
+        }
+    }
+    return effectiveImagePosition;
 }
 
 @end


### PR DESCRIPTION
Updated code to support macOS versions earlier than 10.12 by:

1.) mapping NSImageLeading and NSImageTrailing image positions to NSImageLeft and NSImageRight respectively when run on macOS 10.12 but ignore these values otherwise.

2.) assumes imageHugsTitle == NO on macOS < 10.12. This property was added in 10.12 and the default value is NO - so it's save to assume this behavior for earlier versions of macOS. 