### PR TITLE
增加按钮松开时是否在点击范围内的响应判断

### DIFF
--- a/SYFlatButton/SYFlatButton/SYFlatButton.m
+++ b/SYFlatButton/SYFlatButton/SYFlatButton.m
@@ -264,7 +264,12 @@
         if (self.momentary) {
             self.state = (self.state == NSOnState) ? NSOffState : NSOnState;
         }
-        [NSApp sendAction:self.action to:self.target from:self];
+        NSPoint eventLocation = [event locationInWindow];
+        NSPoint point = [self convertPoint:eventLocation fromView:nil];
+        if (NSPointInRect(point, self.bounds)) {
+            //松开位置在按钮范围内
+            [NSApp sendAction:self.action to:self.target from:self];
+        }
     }
 }
 


### PR DESCRIPTION
如果用户松开鼠标，鼠标位置不在按钮范围内，应该不响应点击事件
If the user releases the mouse, the mouse position is not in the button range, should not respond to the click event.